### PR TITLE
fix: add PackageIcon to make icon visible on NuGet

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,7 @@
   <PropertyGroup>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').EndsWith('.Tests')) == 'True'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>14</LangVersion>
-    <AssemblyVersion>1.0.0.102</AssemblyVersion>
-    <FileVersion>1.0.0.102</FileVersion>
-    <Version>1.0.0</Version>
+    <AssemblyVersion>1.0.1.103</AssemblyVersion>
+    <FileVersion>1.0.1.103</FileVersion>
+    <Version>1.0.1</Version>
     <PackageProjectUrl>https://github.com/Esolang-NET/Brainfuck/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Esolang-NET/Brainfuck.git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
PackageIcon プロパティが未設定だったため NuGet 上でアイコンが表示されていなかった問題を修正。\n\n- \Directory.Build.props\ に \<PackageIcon>icon.png</PackageIcon>\ を追加\n- icon.png 自体は既に全パッケージに \Pack=true\ で同梱済みだったため、プロパティを追記するだけで対応完了