### PR TITLE
V1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog.
 
 - Package metadata: added NuGet `PackageTags` for packable Brainfuck packages (`Generator`, `Parser`, `Processor`, `dotnet-brainfuck`) to improve search/discovery.
 - Fixed a Source Generator load failure where the Generator could not resolve `Esolang.Brainfuck.Parser` at build time; added a `buildTransitive` `.targets` file to ensure Parser assemblies are included as analyzers.
+- `Esolang.Brainfuck.Generator`: `PT0008` / `PT0007` Severity `Error`→ `Hidden`
 
 ## [1.1.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Package metadata: added NuGet `PackageTags` for packable Brainfuck packages (`Generator`, `Parser`, `Processor`, `dotnet-brainfuck`) to improve search/discovery.
+
 ## [1.1.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog.
 
 ## [Unreleased]
 
+## [1.1.1]
+
 ### Changed
 
 - Package metadata: added NuGet `PackageTags` for packable Brainfuck packages (`Generator`, `Parser`, `Processor`, `dotnet-brainfuck`) to improve search/discovery.
@@ -29,6 +31,7 @@ The format is based on Keep a Changelog.
 ## [1.0.0] - 2026-05-06
 
 ### Added
+
 - Generator: Added C# language version check (BF0010) to warn if below C# 8.0.
 - Generator: Added support for `System.IO.TextReader`/`TextWriter` input/output patterns.
 - Generator: Added BF0009 (Hidden) diagnostic for unused input parameters.
@@ -36,40 +39,46 @@ The format is based on Keep a Changelog.
 - CI: Added release workflow to GitHub Actions.
 
 ### Changed
+
 - Generator: Diagnostic messages and ID structure unified with the Piet project.
 - Generator: Clarified signature validation and combination rules.
 - All READMEs: Rewritten in English, reorganized, and expanded with install, usage, and API details.
 - Build/package baseline: unified repository `Version` to `1.0.0`, unified `LangVersion` to C# 14, and set `AssemblyVersion` / `FileVersion` to `1.0.0.102`.
 
 ### Fixed
+
 - Generator: Improved accuracy of duplicate/invalid input/output parameter detection.
 - Tests: Target frameworks now auto-switch for Windows/non-Windows environments.
 
 ## [0.1.1-preview-1] - 2026-04-16
 
 ### Added
+
 - Added Interpreter test project with option binding and command registration tests.
 - Added dotnet tool E2E checks in CI for pack/install/run/parse flow (PR workflow).
 - Added XML documentation enforcement for packable projects.
 
 ### Changed
+
 - Replaced file-based sample app with a csproj-based sample that supports net8.0, net9.0, and net10.0.
 - Aggregated generated methods into a single generated source file.
 - Updated README files for pre-release consistency and usage guidance.
 
 ### Fixed
+
 - Fixed duplicate generated source headers in aggregated generator output.
 - Removed unnecessary System.Memory package references.
 - Fixed `--syntax-increment-current` option registration in Interpreter CLI.
 
 ### Package Notes
+
 - Generator: aggregation output and header deduplication updates.
 - Interpreter: new tests, CLI option registration fix, and tool E2E CI coverage.
 - Parser: README output text typo corrections.
 - Processor: README sample updated to use `BrainfuckProcessor`.
 
 [Unreleased]: https://github.com/Esolang-NET/Brainfuck/compare/v1.1.0...HEAD
-[0.1.1-preview-1]: https://github.com/Esolang-NET/Brainfuck/tree/v0.1.1-preview-1
-[1.0.0]: https://github.com/Esolang-NET/Brainfuck/tree/v1.0.0
-[1.0.1]: https://github.com/Esolang-NET/Brainfuck/tree/v1.0.1
+[1.1.1]: https://github.com/Esolang-NET/Brainfuck/tree/v1.1.1
 [1.1.0]: https://github.com/Esolang-NET/Brainfuck/tree/v1.1.0
+[1.0.0]: https://github.com/Esolang-NET/Brainfuck/tree/v1.0.0
+[0.1.1-preview-1]: https://github.com/Esolang-NET/Brainfuck/tree/v0.1.1-preview-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,9 @@ The format is based on Keep a Changelog.
 - Interpreter: new tests, CLI option registration fix, and tool E2E CI coverage.
 - Parser: README output text typo corrections.
 - Processor: README sample updated to use `BrainfuckProcessor`.
+
+[Unreleased]: https://github.com/Esolang-NET/Brainfuck/compare/v1.1.0...HEAD
+[0.1.1-preview-1]: https://github.com/Esolang-NET/Brainfuck/tree/v0.1.1-preview-1
+[1.0.0]: https://github.com/Esolang-NET/Brainfuck/tree/v1.0.0
+[1.0.1]: https://github.com/Esolang-NET/Brainfuck/tree/v1.0.1
+[1.1.0]: https://github.com/Esolang-NET/Brainfuck/tree/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog.
 ### Changed
 
 - Package metadata: added NuGet `PackageTags` for packable Brainfuck packages (`Generator`, `Parser`, `Processor`, `dotnet-brainfuck`) to improve search/discovery.
+- Fixed a Source Generator load failure where the Generator could not resolve `Esolang.Brainfuck.Parser` at build time; added a `buildTransitive` `.targets` file to ensure Parser assemblies are included as analyzers.
 
 ## [1.1.0] - 2026-05-08
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>14</LangVersion>
-    <AssemblyVersion>1.1.0.104</AssemblyVersion>
-    <FileVersion>1.1.0.104</FileVersion>
-    <Version>1.1.0</Version>
+    <AssemblyVersion>1.1.1.105</AssemblyVersion>
+    <FileVersion>1.1.1.105</FileVersion>
+    <Version>1.1.1</Version>
     <PackageProjectUrl>https://github.com/Esolang-NET/Brainfuck/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Esolang-NET/Brainfuck.git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Generator.Tests/BrainfuckMethodGeneratorTests.cs
+++ b/Generator.Tests/BrainfuckMethodGeneratorTests.cs
@@ -469,6 +469,7 @@ partial class TestClass
     }
     [TestMethod]
     [DynamicData(nameof(DiagnoticsTestData))]
+    [Timeout(50000, CooperativeCancellation = true)]
     public void DiagnoticsTest(string expected, string source, string returnType, string parameters, string options)
     {
         source = $$"""

--- a/Generator/AnalyzerReleases.Shipped.md
+++ b/Generator/AnalyzerReleases.Shipped.md
@@ -21,3 +21,13 @@ BF0006 | Brainfuck | Error | [DiagnosticDescriptors](./Rules/BF0006.md)
 BF0007 | Brainfuck | Error | [DiagnosticDescriptors](./Rules/BF0007.md)
 BF0008 | Brainfuck | Error | [DiagnosticDescriptors](./Rules/BF0008.md)
 BF0009 | Brainfuck | Hidden | [DiagnosticDescriptors](./Rules/BF0009.md)
+
+
+## Release 0.1.1.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+BF0007 | Brainfuck | Hidden | [DiagnosticDescriptors](./Rules/BF0007.md)
+BF0008 | Brainfuck | Hidden | [DiagnosticDescriptors](./Rules/BF0008.md)s

--- a/Generator/DiagnosticDescriptors.cs
+++ b/Generator/DiagnosticDescriptors.cs
@@ -83,7 +83,7 @@ public static class DiagnosticDescriptors
         title: "Required output interface not provided",
         messageFormat: "The Brainfuck source requires output, but the method does not provide an output mechanism",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Error,
+        defaultSeverity: DiagnosticSeverity.Hidden,
         isEnabledByDefault: true);
 
     /// <summary>
@@ -94,7 +94,7 @@ public static class DiagnosticDescriptors
         title: "Required input interface not provided",
         messageFormat: "The Brainfuck source requires input, but the method does not provide an input mechanism",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Error,
+        defaultSeverity: DiagnosticSeverity.Hidden,
         isEnabledByDefault: true);
 
     /// <summary>

--- a/Generator/Esolang.Brainfuck.Generator.csproj
+++ b/Generator/Esolang.Brainfuck.Generator.csproj
@@ -8,6 +8,7 @@
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <IsPublishable>false</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>esolang;brainfuck;generator;source-generator;roslyn-analyzer</PackageTags>
 
     <!-- NuGet packaging settings. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/Generator/Esolang.Brainfuck.Generator.csproj
+++ b/Generator/Esolang.Brainfuck.Generator.csproj
@@ -44,19 +44,25 @@
 
   <!-- Place analyzer output under analyzers/dotnet/cs in the package. -->
   <ItemGroup>
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Esolang.Brainfuck.Parser.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <!-- See https://github.com/dotnet/roslyn-sdk/blob/0313c80ed950ac4f4eef11bb2e1c6d1009b328c4/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SourceGeneratorSamples.csproj#L13-L30
   and https://github.com/dotnet/roslyn/discussions/47517#discussioncomment-64145 -->
   <PropertyGroup>
-    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
+    <GetTargetPathDependsOn>$(GetTargetPathDependsOn)</GetTargetPathDependsOn>
   </PropertyGroup>
 
-  <Target Name="GetDependencyTargetPaths">
+  <Target Name="CopyAnalyzerDependencies" AfterTargets="Build">
     <ItemGroup>
-      <TargetPathWithTargetPlatformMoniker Include="$(ProjectDir)..\Parser\$(OutputPath)\*.dll" IncludeRuntimeDependency="false" />
+      <AnalyzerDependency Include="@(ReferenceCopyLocalPaths)" />
     </ItemGroup>
+
+    <Copy
+      SourceFiles="@(AnalyzerDependency)"
+      DestinationFolder="$(OutputPath)"
+      SkipUnchangedFiles="true" />
   </Target>
 
   <ItemGroup>

--- a/Generator/MethodGenerator.Emit.cs
+++ b/Generator/MethodGenerator.Emit.cs
@@ -47,7 +47,6 @@ public partial class MethodGenerator
                     DiagnosticDescriptors.RequiredOutputInterface,
                     methodDeclarationSyntax.Identifier.GetLocation())
             );
-            return null;
         }
         if (sequences.RequiredInput
             && string.IsNullOrEmpty(parameterOptions.VariablePipeReader)
@@ -60,7 +59,6 @@ public partial class MethodGenerator
                     DiagnosticDescriptors.RequiredInputInterface,
                     methodDeclarationSyntax.Identifier.GetLocation())
             );
-            return null;
         }
 
         var (openingDefinitionCode, codeForClosingDefinition) = Utils.GenerateOpeningClosingTypeDefinitionCode(methodSymbol);

--- a/Generator/Properties/launchSettings.json
+++ b/Generator/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "debug": {
-      "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\Generator.UseConsole\\Esolang.Brainfuck.Generator.UseConsole.csproj"
-    }
-  }
-}

--- a/Generator/buildTransitive/Esolang.Brainfuck.Generator.targets
+++ b/Generator/buildTransitive/Esolang.Brainfuck.Generator.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup Condition="'$(MSBuildThisPackageRoot)' != ''">
+    <Analyzer Include="$(MSBuildThisPackageRoot)analyzers/dotnet/cs/Esolang.Brainfuck.Generator.dll" />
+    <Analyzer Include="$(MSBuildThisPackageRoot)analyzers/dotnet/cs/Esolang.Brainfuck.Parser.dll" />
+  </ItemGroup>
+</Project>

--- a/Interpreter/Esolang.Brainfuck.Interpreter.csproj
+++ b/Interpreter/Esolang.Brainfuck.Interpreter.csproj
@@ -12,6 +12,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-brainfuck</ToolCommandName>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>esolang;brainfuck;interpreter;cli;dotnet-tool</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Parser/Esolang.Brainfuck.Parser.csproj
+++ b/Parser/Esolang.Brainfuck.Parser.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <IsPublishable>false</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>esolang;brainfuck;parser</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   

--- a/Processor/Esolang.Brainfuck.Processor.csproj
+++ b/Processor/Esolang.Brainfuck.Processor.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <IsPublishable>false</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>esolang;brainfuck;processor</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/samples/Generator.UseConsole/Esolang.Brainfuck.Generator.UseConsole.csproj
+++ b/samples/Generator.UseConsole/Esolang.Brainfuck.Generator.UseConsole.csproj
@@ -15,8 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- use Esolang.Brainfuck.Generator analyzer project -->
+    <!-- Use local source generator project as analyzer during repository development -->
     <ProjectReference Include="..\..\Generator\Esolang.Brainfuck.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Keep local development aligned with the packed analyzer layout: the generator is referenced once,
+         while its non-analyzer dependencies are provided from the same build output folder. -->
+    <Analyzer Include="..\..\Generator\bin\$(Configuration)\netstandard2.0\Esolang.Brainfuck.Parser.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Changed

- Package metadata: added NuGet `PackageTags` for packable Brainfuck packages (`Generator`, `Parser`, `Processor`, `dotnet-brainfuck`) to improve search/discovery.
- Fixed a Source Generator load failure where the Generator could not resolve `Esolang.Brainfuck.Parser` at build time; added a `buildTransitive` `.targets` file to ensure Parser assemblies are included as analyzers.
- `Esolang.Brainfuck.Generator`: `PT0008` / `PT0007` Severity `Error`→ `Hidden`